### PR TITLE
#3 #5 check for wc version, updated client library

### DIFF
--- a/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
+++ b/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
@@ -8,7 +8,7 @@
  *
  */
 define('WOOCOMMERCE_GATEWAY_WCP_NAME', 'Woocommerce2_WirecardCheckoutPage');
-define('WOOCOMMERCE_GATEWAY_WCP_VERSION', '1.1.5');
+define('WOOCOMMERCE_GATEWAY_WCP_VERSION', '1.1.6');
 define('WOOCOMMERCE_GATEWAY_WCP_WINDOWNAME', 'WirecardCheckoutPageFrame');
 define('WOOCOMMERCE_GATEWAY_WCP_TABLE_NAME', 'woocommerce_wcp_transaction');
 define('WOOCOMMERCE_GATEWAY_WCP_INVOICE_INSTALLMENT_MIN_AGE', 18);

--- a/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
+++ b/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
@@ -490,13 +490,17 @@ class WC_Gateway_WCP extends WC_Payment_Gateway
 
         if ($this->use_iframe) {
             WC()->session->wirecard_checkout_page_type = $paymenttype;
+
+            $page_url = version_compare(WC()->version, '2.1.0', '<')
+                ? get_permalink(wc_get_page_id('pay'))
+                : WC_Order::get_checkout_payment_url( true );
+
+            $page_url = add_query_arg('key',$order->order_key, $page_url);
+            $page_url = add_query_arg('order', $order_id, $page_url);
+
             return array(
                 'result' => 'success',
-                'redirect' => add_query_arg(
-                    'key',
-                    $order->order_key,
-                    add_query_arg('order', $order_id, get_permalink(wc_get_page_id('pay')))
-                )
+                'redirect' => $page_url
             );
         } else {
             $redirectUrl = $this->initiate_payment($order, $paymenttype);

--- a/woocommerce-wirecard-checkout-page/woocommerce-wirecard-checkout-page.php
+++ b/woocommerce-wirecard-checkout-page/woocommerce-wirecard-checkout-page.php
@@ -6,7 +6,7 @@
 Plugin Name: Wirecard Checkout Page
 Plugin URI: http://www.wirecard.at/integration/plugins/
 Description: Wirecard CEE is a popular payment service provider (PSP) and has connections with over 20 national and international currencies.
-Version: 1.1.5
+Version: 1.1.6
 Author: Wirecard Central Eastern Europe
 Author URI: http://www.wirecard.at/
 License: Proprietary


### PR DESCRIPTION
- if the wc version is lower than 2.1.0 wc_get_page_id() is used
otherwise the new WC_Order::get_checkout_payment_url() is used