### PR TITLE
Fix: use home_url() instead of site_url()

### DIFF
--- a/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
+++ b/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
@@ -546,7 +546,7 @@ class WC_Gateway_WCP extends WC_Payment_Gateway
 
             // do iframe breakout, if needed and not already done
             if ($this->use_iframe && !array_key_exists('redirected', $_REQUEST)) {
-                $url = add_query_arg('wc-api', 'WC_Gateway_WCP', site_url('/', is_ssl() ? 'https' : 'http'));
+                $url = add_query_arg('wc-api', 'WC_Gateway_WCP', home_url('/', is_ssl() ? 'https' : 'http'));
                 wc_get_template(
                     'templates/iframebreakout.php',
                     array(
@@ -983,7 +983,7 @@ class WC_Gateway_WCP extends WC_Payment_Gateway
                 $this->set_consumer_information($order, $consumerData);
             }
 
-            $returnUrl = add_query_arg('wc-api', 'WC_Gateway_WCP', site_url('/', is_ssl() ? 'https' : 'http'));
+            $returnUrl = add_query_arg('wc-api', 'WC_Gateway_WCP', home_url('/', is_ssl() ? 'https' : 'http'));
 
             $version = WirecardCEE_QPay_FrontendClient::generatePluginVersion(
                 $this->get_vendor(),


### PR DESCRIPTION
Hi,

I have a website where WordPress is installed in [subdirectory](https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory), therefore site home page is different from WordPress installation directory:

```php
// Get URL of site homepage
echo home_url();
// Prints: https://shop.example.com

// Get URL of WordPress installation directory
echo site_url();
// Prints: https://shop.example.com/wordpress
```

The latter is not a valid front-end URL at my site. Unfortunately, I had to adapt Wirecard Checkout Page plugin, because it uses site_url() in places when home_url() should be used instead. Would be nice, if you could merge this change in your plugin.

All the best,
Česlav