### PR TITLE
#44 Update save data for failed payment

### DIFF
--- a/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
+++ b/woocommerce-wirecard-checkout-page/class-woocommerce-wcp-gateway.php
@@ -390,7 +390,9 @@ class WC_Gateway_WCP extends WC_Payment_Gateway {
 		$str = trim( $str );
 
 		update_post_meta( $order->get_id(), 'wcp_data', $str );
-		update_post_meta( $order->get_id(), '_payment_method', $_REQUEST['paymentType'] );
+		if ( isset( $_REQUEST['paymentType'] ) ) {
+			update_post_meta($order->get_id(), '_payment_method', $_REQUEST['paymentType']);
+		}
 
 		$message = null;
 		try {


### PR DESCRIPTION
Root cause: For an error report the return call does not contain the field 'paymentType' - it is only available for successful/pending payments.

So the solution is a simple pre-check if the field is set before saving it in WooCommerce.